### PR TITLE
added support for x-mock-match-request-body

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,10 @@
 'use strict'
 const express = require('express')
 const app = express()
+app.use(express.json());
+
+const _ = require("lodash");
+
 
 class PostmanMockServer {
   constructor (port, collection) {
@@ -41,6 +45,7 @@ class PostmanMockServer {
       routes.push(item.request.method + " " + methodPath)
 
       dynamicApiRouter.all(methodPath, (req, res) => {
+        
         //This callback is invoked outside of the parent 'for' loop, so the item object is not available here.
         let responseSent = false
         let potentialItems = []
@@ -98,6 +103,11 @@ class PostmanMockServer {
               return response.code == req.headers['x-mock-response-code']
             }
 
+            //Case 4: x-response-match-body header is set
+            if (req.headers['x-mock-match-request-body'] === "true") {
+              return _.isEqual(req.body,JSON.parse(response.originalRequest.body.raw))
+            }
+
             //Case 4: Default Case: let's try and match on the method, path and headers.
             let currentPath = req.path;
 
@@ -135,6 +145,8 @@ class PostmanMockServer {
             }
           })
 
+
+
           if (response) {
             //We've got a response! Send it back.
             res.status(response.code)
@@ -145,7 +157,7 @@ class PostmanMockServer {
         }
 
         if (!responseSent)
-          res.status(500).send('Error processing mock server request.')
+          res.status(404).send('Error processing mock server request.')
       })
     }
 
@@ -178,5 +190,7 @@ function findRequests (items, requests) {
     }
   }
 }
+
+
 
 module.exports = PostmanMockServer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "postman-local",
+  "name": "@jordanwalsh23/postman-local-mock-server",
   "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "postman-local",
+      "name": "@jordanwalsh23/postman-local-mock-server",
       "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
-        "express": "^4.18.1"
+        "express": "^4.18.1",
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
         "axios": "^0.27.2",
@@ -879,6 +880,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -2181,6 +2187,11 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "log-symbols": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "express": "^4.18.1"
+    "express": "^4.18.1",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "axios": "^0.27.2",

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@ This project brings Postman's collection mocking capability locally enabling you
 - Create a local mock server by supplying a Postman Collection.
 - Customizable TCP Port number for your mock server.
 - Supports the `x-mock-response-name` and `x-mock-response-code` headers to specify the response you want returned by either name or status code.
+- Supports the `x-mock-match-request-body` header to match responses on POST/PATCH/PUT requests.
 
 ## Getting Started
 

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -1,48 +1,115 @@
-const fs = require('fs');
-const PostmanLocalMockServer = require('../index.js');
-const axios = require('axios').default;
-const assert = require('assert');
+const fs = require('fs')
+const PostmanLocalMockServer = require('../index.js')
+const axios = require('axios').default
+const assert = require('assert')
 
-const PORT = 3555;
+const PORT = 3555
 
-let server;
+let server
 
 describe('Postman Local Mock Server Tests', () => {
-
   before(() => {
-    let collection = JSON.parse(fs.readFileSync('./test/test-collection.json', 'utf8'));
-    server = new PostmanLocalMockServer(PORT, collection);
-    server.start();
-  });
+    let collection = JSON.parse(
+      fs.readFileSync('./test/test-collection.json', 'utf8')
+    )
+    server = new PostmanLocalMockServer(PORT, collection)
+    server.start()
+  })
 
-  it('Default response test.', async () => {
-    return await axios.get(`http://localhost:${PORT}/get`).then(res => {
-      assert(res.data.args.name === "Jordan")
-    });
-  });
-
-  it('x-mock-response-name test.', async () => {
-    return await axios.get(`http://localhost:${PORT}/get`, {
-      headers: {
-        'x-mock-response-name': "200 Different Name"
-      }
-    }).then(res => {
-      assert(res.data.args.name === "Not Jordan")
-    });
-  });
-
-  it('x-mock-response-code test.', async () => {
-    return await axios.get(`http://localhost:${PORT}/get`, {
-      headers: {
-        'x-mock-response-code': 201
-      }
-    }).then(res => {
-      assert(res.status === 201);
-      assert(res.data.message === "Item has been created.");
+  describe('Default request tests', () => {
+    it('Default GET response test.', async () => {
+      return await axios.get(`http://localhost:${PORT}/get`).then(res => {
+        assert(res.data.args.name === 'Jordan')
+      })
     })
-  });
+
+    it('x-mock-response-name test.', async () => {
+      return await axios
+        .get(`http://localhost:${PORT}/get`, {
+          headers: {
+            'x-mock-response-name': '200 Different Name'
+          }
+        })
+        .then(res => {
+          assert(res.data.args.name === 'Not Jordan')
+        })
+    })
+
+    it('x-mock-response-code test.', async () => {
+      return await axios
+        .get(`http://localhost:${PORT}/get`, {
+          headers: {
+            'x-mock-response-code': 201
+          }
+        })
+        .then(res => {
+          assert(res.status === 201)
+          assert(res.data.message === 'Item has been created.')
+        })
+    })
+  })
+
+  describe('POST request tests', () => {
+    it('Default POST response test.', async () => {
+      return await axios.post(`http://localhost:${PORT}/post`)
+      .then(res => res.data)
+      .then(res => {
+        assert(res.data.number === 1)
+        assert(res.data.text === "Quick Brown Fox")
+      })
+    })
+
+    it('POST response with different body.', async () => {
+      return await axios.post(`http://localhost:${PORT}/post`, {
+          number: 2,
+          text: "Jumped Over The"
+      },{
+        headers: {
+          'x-mock-match-request-body': 'true',
+          'content-type': 'application/json'
+        }
+      })
+      .then(res => res.data)
+      .then(res => {
+        assert(res.data.number === 2)
+        assert(res.data.text === "Jumped Over The")
+      })
+    })
+
+    it('POST response with specific response selected.', async () => {
+      return await axios.post(`http://localhost:${PORT}/post`, {
+          number: 2,
+          text: "Jumped Over The"
+      },{
+        headers: {
+          'x-mock-response-name': 'Alternate Response 2',
+          'content-type': 'application/json'
+        }
+      })
+      .then(res => res.data)
+      .then(res => {
+        assert(res.data.number === 2)
+        assert(res.data.text === "Jumped Over The")
+      })
+    })
+
+    it('POST response with an unknown body.', async () => {
+      return await axios.post(`http://localhost:${PORT}/post`, {
+          number: 999,
+          text: "Fred"  
+      },{
+        headers: {
+          'x-mock-match-request-body': 'true',
+          'content-type': 'application/json'
+        }
+      })
+      .catch(err => {
+        assert(err.response.status === 404)
+      });
+    })
+  })
 
   after(() => {
-    server.stop();
-  });
+    server.stop()
+  })
 })

--- a/test/test-collection.json
+++ b/test/test-collection.json
@@ -8,6 +8,26 @@
 	"item": [
 		{
 			"name": "Get Request",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
 			"request": {
 				"method": "GET",
 				"header": [],
@@ -31,7 +51,7 @@
 			},
 			"response": [
 				{
-					"name": "Get Request",
+					"name": "Default Response",
 					"originalRequest": {
 						"method": "GET",
 						"header": [],
@@ -155,6 +175,241 @@
 					],
 					"cookie": [],
 					"body": "{\n    \"status\": 201,\n    \"message\": \"Item has been created.\"\n}"
+				}
+			]
+		},
+		{
+			"name": "Post Request",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"number\": 1,\n    \"text\": \"Quick Brown Fox\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "https://postman-echo.com/post",
+					"protocol": "https",
+					"host": [
+						"postman-echo",
+						"com"
+					],
+					"path": [
+						"post"
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "Default Response",
+					"originalRequest": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"number\": 1,\n    \"text\": \"Quick Brown Fox\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://postman-echo.com/post",
+							"protocol": "https",
+							"host": [
+								"postman-echo",
+								"com"
+							],
+							"path": [
+								"post"
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Thu, 11 Aug 2022 06:30:14 GMT"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8"
+						},
+						{
+							"key": "Content-Length",
+							"value": "540"
+						},
+						{
+							"key": "Connection",
+							"value": "keep-alive"
+						},
+						{
+							"key": "ETag",
+							"value": "W/\"21c-tUFCuSlE6wgy0e+PB5n//tlPsBg\""
+						},
+						{
+							"key": "Vary",
+							"value": "Accept-Encoding"
+						},
+						{
+							"key": "set-cookie",
+							"value": "sails.sid=s%3AUeR53xhsUAhhq3dzuqi_V-PcyGYOeZ2B.kldaxi4NJXnm6qILsZwAm4W0bpsyxHQqq9JutVS3Ce0; Path=/; HttpOnly"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"args\": {},\n    \"data\": {\n        \"number\": 1,\n        \"text\": \"Quick Brown Fox\"\n    },\n    \"files\": {},\n    \"form\": {},\n    \"headers\": {\n        \"x-forwarded-proto\": \"https\",\n        \"x-forwarded-port\": \"443\",\n        \"host\": \"postman-echo.com\",\n        \"x-amzn-trace-id\": \"Root=1-62f4a1f6-1cf6f0ce2c7b04a3487bc129\",\n        \"content-length\": \"50\",\n        \"content-type\": \"application/json\",\n        \"user-agent\": \"PostmanRuntime/7.29.2\",\n        \"accept\": \"*/*\",\n        \"cache-control\": \"no-cache\",\n        \"postman-token\": \"5a10961a-c7c4-4cfd-8a55-5eecb395e0ca\",\n        \"accept-encoding\": \"gzip, deflate, br\"\n    },\n    \"json\": {\n        \"number\": 1,\n        \"text\": \"Quick Brown Fox\"\n    },\n    \"url\": \"https://postman-echo.com/post\"\n}"
+				},
+				{
+					"name": "Alternate Response 2",
+					"originalRequest": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"number\": 2,\n    \"text\": \"Jumped Over The\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://postman-echo.com/post",
+							"protocol": "https",
+							"host": [
+								"postman-echo",
+								"com"
+							],
+							"path": [
+								"post"
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Thu, 11 Aug 2022 06:30:14 GMT"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8"
+						},
+						{
+							"key": "Content-Length",
+							"value": "540"
+						},
+						{
+							"key": "Connection",
+							"value": "keep-alive"
+						},
+						{
+							"key": "ETag",
+							"value": "W/\"21c-tUFCuSlE6wgy0e+PB5n//tlPsBg\""
+						},
+						{
+							"key": "Vary",
+							"value": "Accept-Encoding"
+						},
+						{
+							"key": "set-cookie",
+							"value": "sails.sid=s%3AUeR53xhsUAhhq3dzuqi_V-PcyGYOeZ2B.kldaxi4NJXnm6qILsZwAm4W0bpsyxHQqq9JutVS3Ce0; Path=/; HttpOnly"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"args\": {},\n    \"data\": {\n        \"number\": 2,\n        \"text\": \"Jumped Over The\"\n    },\n    \"files\": {},\n    \"form\": {},\n    \"headers\": {\n        \"x-forwarded-proto\": \"https\",\n        \"x-forwarded-port\": \"443\",\n        \"host\": \"postman-echo.com\",\n        \"x-amzn-trace-id\": \"Root=1-62f4a1f6-1cf6f0ce2c7b04a3487bc129\",\n        \"content-length\": \"50\",\n        \"content-type\": \"application/json\",\n        \"user-agent\": \"PostmanRuntime/7.29.2\",\n        \"accept\": \"*/*\",\n        \"cache-control\": \"no-cache\",\n        \"postman-token\": \"5a10961a-c7c4-4cfd-8a55-5eecb395e0ca\",\n        \"accept-encoding\": \"gzip, deflate, br\"\n    },\n    \"json\": {\n        \"number\": 1,\n        \"text\": \"Quick Brown Fox\"\n    },\n    \"url\": \"https://postman-echo.com/post\"\n}"
+				},
+				{
+					"name": "Alternate Response 3",
+					"originalRequest": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"number\": 3,\n    \"text\": \"Lazy Dog\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://postman-echo.com/post",
+							"protocol": "https",
+							"host": [
+								"postman-echo",
+								"com"
+							],
+							"path": [
+								"post"
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Date",
+							"value": "Thu, 11 Aug 2022 06:30:14 GMT"
+						},
+						{
+							"key": "Content-Type",
+							"value": "application/json; charset=utf-8"
+						},
+						{
+							"key": "Content-Length",
+							"value": "540"
+						},
+						{
+							"key": "Connection",
+							"value": "keep-alive"
+						},
+						{
+							"key": "ETag",
+							"value": "W/\"21c-tUFCuSlE6wgy0e+PB5n//tlPsBg\""
+						},
+						{
+							"key": "Vary",
+							"value": "Accept-Encoding"
+						},
+						{
+							"key": "set-cookie",
+							"value": "sails.sid=s%3AUeR53xhsUAhhq3dzuqi_V-PcyGYOeZ2B.kldaxi4NJXnm6qILsZwAm4W0bpsyxHQqq9JutVS3Ce0; Path=/; HttpOnly"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"args\": {},\n    \"data\": {\n        \"number\": 3,\n        \"text\": \"Lazy Dog\"\n    },\n    \"files\": {},\n    \"form\": {},\n    \"headers\": {\n        \"x-forwarded-proto\": \"https\",\n        \"x-forwarded-port\": \"443\",\n        \"host\": \"postman-echo.com\",\n        \"x-amzn-trace-id\": \"Root=1-62f4a1f6-1cf6f0ce2c7b04a3487bc129\",\n        \"content-length\": \"50\",\n        \"content-type\": \"application/json\",\n        \"user-agent\": \"PostmanRuntime/7.29.2\",\n        \"accept\": \"*/*\",\n        \"cache-control\": \"no-cache\",\n        \"postman-token\": \"5a10961a-c7c4-4cfd-8a55-5eecb395e0ca\",\n        \"accept-encoding\": \"gzip, deflate, br\"\n    },\n    \"json\": {\n        \"number\": 1,\n        \"text\": \"Quick Brown Fox\"\n    },\n    \"url\": \"https://postman-echo.com/post\"\n}"
 				}
 			]
 		}


### PR DESCRIPTION
Users can now add the `x-mock-match-request-body` header to requests to the postman local mock server and it will attempt to find an example response that contains the same payload as the request.

Note, this only works for JSON requests.