### PR TITLE
fix(server): set response code only if is defined in collection

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -173,7 +173,9 @@ class PostmanMockServer {
 
             //TBD - Replace collection level variables.
 
-            res.status(response.code)
+            if (response.code) {
+              res.status(response.code)
+            }
             
             response && response.header ? response.header.forEach(header => {
               res.set(header.key, header.value)


### PR DESCRIPTION
I don't know why, but I have a collection without a response code