### PR TITLE
Feat/add levenshtein distance calculations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .history
 node_modules
+.DS_Store

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
+const distance = require('fastest-levenshtein').distance
 
 function getMatchedResponse(req, responses, debug) {
     var bestMatchedResponse = null;
@@ -7,11 +8,11 @@ function getMatchedResponse(req, responses, debug) {
     //1. Filter on METHOD
     let method = req.method;
 
-    responses = responses.filter(response => {
+    responsesToProcess = responses.filter(response => {
         return response.originalRequest.method == method;
     })
 
-    if (responses.length == 0) {
+    if (responsesToProcess.length == 0) {
         return;
     }
 
@@ -35,7 +36,7 @@ function getMatchedResponse(req, responses, debug) {
         debug && console.log('Scoring on x-mock selector')
         //we've used a selector, so if no responses match we have to move on.
         //Look through the responses on this particular request and see if we can get a match.
-        let matchedPostmanHeadersResponse = responses.find(response => {
+        let matchedPostmanHeadersResponse = responsesToProcess.find(response => {
             //Case 1: x-response-mock-name header is set
             if (req.headers['x-mock-response-name']) {
                 return response.name == req.headers['x-mock-response-name']
@@ -66,7 +67,7 @@ function getMatchedResponse(req, responses, debug) {
     let results = {};
 
     debug && console.log('Scoring path structure match')
-    responses.every(response => {
+    responsesToProcess.every(response => {
         results[response.id] = {
             score: 100
         };
@@ -77,13 +78,15 @@ function getMatchedResponse(req, responses, debug) {
         )}`
 
         //3.1.1 Perfect Score
-        debug && console.log(`${req.path} eq /${thisResponsePath}`, _.isEqual(req.path, `/${thisResponsePath}`))
+        debug && console.log(`Perfect Match: ${req.path} eq /${thisResponsePath}`, _.isEqual(req.path, `/${thisResponsePath}`))
 
         if (_.isEqual(req.path, `/${thisResponsePath}`)) {
             return true;
         }
 
         //3.1.2 Compare case insensitive
+        debug && console.log(`Case insensitive match: ${req.path.toLowerCase()} eq /${thisResponsePath.toLowerCase()}`, _.isEqual(req.path.toLowerCase(), `/${thisResponsePath.toLowerCase()}`))
+
         if (_.isEqual(req.path.toLowerCase(), `/${thisResponsePath.toLowerCase()}`)) {
             results[response.id].score -= 10;
             return true;
@@ -93,18 +96,45 @@ function getMatchedResponse(req, responses, debug) {
         let newReqPath = req.path.replace(/\/?\s*$/g, '');
         let newResPath = thisResponsePath.replace(/\/?\s*$/g, '');
 
+        debug && console.log(`Removed trailing slashes match: ${newReqPath} eq /${newResPath}`, _.isEqual(newReqPath, `/${newResPath}`))
+
         if (_.isEqual(newReqPath, `/${newResPath}`)) {
             results[response.id].score -= 5;
             return true;
         }
 
         //3.1.4 Remove trailing slashes and case insensitive
+
+        debug && console.log(`Removed trailing slashes and case insensitive match: ${newReqPath.toLowerCase()} eq /${newResPath.toLowerCase()}`, _.isEqual(newReqPath.toLowerCase(), `/${newResPath.toLowerCase()}`))
+
         if (_.isEqual(newReqPath.toLowerCase(), `/${newResPath.toLowerCase()}`)) {
             results[response.id].score -= 15;
             return true;
         }
 
-        //3.1.5 Remove wildcards and variables and test match
+        //3.1.5 Compare the URLs with the alphanumeric IDs removed.
+        let reqIDsRemoved = stripPotentialIDs(req.path.toLowerCase());
+        let resIDsRemoved = stripPotentialIDs(`/${thisResponsePath.toLowerCase()}`);
+
+        debug && console.log(`Compare with IDs removed: ${reqIDsRemoved} eq ${resIDsRemoved}`, _.isEqual(reqIDsRemoved, `${resIDsRemoved}`))
+
+        if (_.isEqual(reqIDsRemoved, `${resIDsRemoved}`)) {
+            results[response.id].score -= 20;
+            return true;
+        }
+
+        //3.1.6 Compare the URLs with the alphanumeric IDs and trailing slashes removed
+        let reqIDsAndSlashesRemoved = stripPotentialIDs(req.path.toLowerCase().replace(/\/$/g, ''));
+        let resIDsAndSlashesRemoved = stripPotentialIDs(`/${thisResponsePath.toLowerCase().replace(/\/$/g, '')}`);
+
+        debug && console.log(`Compare with IDs and trailing slashes removed: ${reqIDsAndSlashesRemoved} eq ${resIDsAndSlashesRemoved}`, _.isEqual(reqIDsAndSlashesRemoved, `${resIDsAndSlashesRemoved}`))
+
+        if (_.isEqual(reqIDsAndSlashesRemoved, `${resIDsAndSlashesRemoved}`)) {
+            results[response.id].score -= 25;
+            return true;
+        }
+
+        //3.1.7 Remove wildcards and variables and test match
         if (thisResponsePath.indexOf(':') > -1) {
             //There are parameters in this response path that we need to accommodate.
             thisResponsePath = thisResponsePath.replace(/:[^\/]+/g, '.+')
@@ -140,18 +170,18 @@ function getMatchedResponse(req, responses, debug) {
         //no match - we need to delete this ID
         delete results[response.id];
         return true;
-        
+
     });
 
     debug && console.log('Scoring query parameters')
 
-    //3.1.6 Match Query Parameters
+    //4. Match Query Parameters
     if (Object.keys(req.query).length > 0) {
 
         //iterate through the results array as these are the only potential matches.
         Object.keys(results).forEach((id) => {
 
-            let response = responses.find(response => response.id == id);
+            let response = responsesToProcess.find(response => response.id == id);
             debug && console.log('Scoring query parameters')
             let fullMatches = 0;
             let partialMatches = 0;
@@ -215,13 +245,14 @@ function getMatchedResponse(req, responses, debug) {
         });
     }
 
-
+    //5. Match Headers
     debug && console.log('Scoring headers and body match')
-    //3.1.7 Match Headers
     if (req.headers['x-mock-match-request-headers'] || req.headers['x-mock-match-request-body']) {
 
+        selectorUsed = true;
+
         //Iterate through the headers on the actual request object and see if we can find a match
-    
+
         //Headers first
         let headersToFind = req.headers['x-mock-match-request-headers'];
 
@@ -235,7 +266,7 @@ function getMatchedResponse(req, responses, debug) {
         //Iterate through the results array as these are the only potential matches
         Object.keys(results).forEach((id) => {
 
-            let response = responses.find(response => response.id == id);
+            let response = responsesToProcess.find(response => response.id == id);
 
             if (headersToFind) {
                 let headersFound = true;
@@ -268,25 +299,29 @@ function getMatchedResponse(req, responses, debug) {
                 req.method.toLowerCase() == 'patch'
             ) {
 
-                if (
-                    response.originalRequest &&
-                    response.originalRequest.body &&
-                    response.originalRequest.body.raw &&
-                    _.isEqual(
-                        req.body,
-                        JSON.parse(response.originalRequest.body.raw))
-                ) {
-                    debug && console.log("body matches increase by 5");
-                    results[id].score += 5;
-                } else {
+                //This is a request that should have a body, we only support JSON comparisons so let's check.
+                if (req.headers['content-type'] && req.headers['content-type'].toLowerCase() == "application/json") {
 
-                    if (req.headers['x-mock-match-request-body'] == 'true') {
-                        delete results[id];
+                    //Now let's validate this response and see if they have a perfect match
+                    if (
+                        response.originalRequest &&
+                        response.originalRequest.body &&
+                        response.originalRequest.body.raw &&
+                        _.isEqual(
+                            req.body,
+                            JSON.parse(response.originalRequest.body.raw))
+                    ) {
+                        debug && console.log("body matches: increase the score by 5");
+                        results[id].score += 5;
+
+                    } else {
+                        if (req.headers['x-mock-match-request-body'] == 'true') {
+                            delete results[id];
+                        }
                     }
-
                 }
             }
-            
+
         });
     }
 
@@ -294,19 +329,122 @@ function getMatchedResponse(req, responses, debug) {
     Object.keys(results).forEach(id => {
         if (results[id].score > bestMatchedResponseScore) {
             bestMatchedResponseScore = results[id].score;
-            bestMatchedResponse = responses.find((response) => response.id == id);
+            bestMatchedResponse = responsesToProcess.find((response) => response.id == id);
         }
     })
 
-    if (!bestMatchedResponse) {
-        debug && console.log("Couldn't find a response")
-    } else {
+    if (!bestMatchedResponse && !selectorUsed) {
+        debug && console.log("Couldn't find a response. Doing the Levenshtein check.")
+
+        //6. Levenshtein URL Document Distance Match
+        debug && console.log('Scoring distance between URL parts')
+
+        responsesToProcess = responses.filter(response => {
+            return response.originalRequest.method == req.method;
+        })
+
+        //Iterate through the results array as these are the only potential matches we have left
+        responsesToProcess.every((response) => {
+
+            let requestUrlParts = req.path.split('/');
+            let responseUrlParts = response && response.originalRequest ? response.originalRequest.url.path : [];
+
+            if (requestUrlParts && requestUrlParts.length > 0 && requestUrlParts[0] == "") {
+                requestUrlParts.shift();
+            }
+
+            if (responseUrlParts && responseUrlParts.length > 0 && responseUrlParts[0] == "") {
+                responseUrlParts.shift();
+            }
+
+            if (requestUrlParts.length != responseUrlParts.length) {
+                return false;
+            }
+
+            let pctRequired = 75;
+            let pctMet = true;
+
+            requestUrlParts.every((part, idx) => {
+                if (part && responseUrlParts[idx]) {
+                    let result = distance(part, responseUrlParts[idx]);
+                    debug && console.log(`URL part ${part} vs ${responseUrlParts[idx]} = ${result}`)
+
+                    let pctDistance = calculatePercentage(part.length - result, part.length);
+                    console.log(`pct distance: ${pctDistance}`);
+
+                    pctMet = pctMet && (pctDistance >= pctRequired);
+                    return pctMet;
+                }
+            });
+
+            if(pctMet) {
+                //TODO: Could be a higher pct found later on. At this stage we are simply returning the first one found that meets the pct.
+                bestMatchedResponse = response;
+                return false;
+            }
+
+            return true;
+
+        });
+
+
+    }
+
+    if (bestMatchedResponse) {
         debug && console.log("Best matched:", bestMatchedResponse.name, bestMatchedResponse.id)
         bestMatchedResponse['score'] = bestMatchedResponseScore;
+    } else {
+        debug && console.log("Couldn't find a response. Returning null.")
     }
 
     return bestMatchedResponse;
 
+}
+
+
+/**
+ * Potential IDs are defined as follows:
+    -  Numbers
+    -  Strings greater than or equal to 256 in length (large strings which might be binary data)
+    -  UUIDs 
+ */
+
+function stripPotentialIDs(url) {
+
+    let parts = url.split('/');
+
+    parts.forEach((part, idx) => {
+
+        if (part && part != "") {
+            //check if this is a number
+            if (!isNaN(part)) {
+                parts[idx] = ""
+            }
+
+            //check if this is a UUID by regex
+            if (/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/.test(part)) {
+                parts[idx] = ""
+            }
+
+            //check if this is a large string
+            if (part.length >= 256) {
+                parts[idx] = ""
+            }
+        }
+
+    })
+
+    return parts.join('/');
+}
+
+
+function calculatePercentage(is, of) {
+    if (_.isEqual(of, 0)) {
+        return 0;
+    }
+
+    // round percentage to the nearest integer
+    return Math.round((is / of) * 100);
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jordanwalsh23/postman-local-mock-server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jordanwalsh23/postman-local-mock-server",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@faker-js/faker": "^7.4.0",
         "apicache-extra": "^1.9.1",
         "express": ">=4.19.2",
+        "fastest-levenshtein": "^1.0.16",
         "follow-redirects": ">=1.15.6",
         "http": "^0.0.1-security",
         "https": "^1.0.0",
@@ -614,6 +615,14 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "engines": {
+        "node": ">= 4.9.1"
       }
     },
     "node_modules/file-type": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jordanwalsh23/postman-local-mock-server",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jordanwalsh23/postman-local-mock-server",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jordanwalsh23/postman-local-mock-server",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Provides the ability to run Postman collections as a local mock server.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jordanwalsh23/postman-local-mock-server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Provides the ability to run Postman collections as a local mock server.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@faker-js/faker": "^7.4.0",
     "apicache-extra": "^1.9.1",
     "express": ">=4.19.2",
+    "fastest-levenshtein": "^1.0.16",
     "follow-redirects": ">=1.15.6",
     "http": "^0.0.1-security",
     "https": "^1.0.0",

--- a/test/collections/document-distance-tests.json
+++ b/test/collections/document-distance-tests.json
@@ -1,0 +1,138 @@
+{
+	"info": {
+		"_postman_id": "380dfd64-d20e-482a-b991-fea6118aa67c",
+		"name": "Test Document Distance",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "18475687"
+	},
+	"item": [
+		{
+			"name": "Perfect Match",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{baseUrl}}/documents/my-document",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"documents",
+						"my-document"
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "Perfect Match",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/documents/my-document",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"documents",
+								"my-document"
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json",
+							"description": "",
+							"type": "text"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"status\" : \"perfect match\"\n}"
+				}
+			]
+		},
+		{
+			"name": "Near Match",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{baseUrl}}/employees/caroline",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"employees",
+						"caroline"
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "Near Match",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/employees/carolyne",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"employees",
+								"carolyne"
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json",
+							"description": "",
+							"type": "text"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"status\": \"near match\"\n}"
+				},
+				{
+					"name": "No Match",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/employees/johnson",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"employees",
+								"johnson"
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json",
+							"description": "",
+							"type": "text"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"status\": \"no match\"\n}"
+				}
+			]
+		}
+	]
+}

--- a/test/collections/strip-alpha-tests.json
+++ b/test/collections/strip-alpha-tests.json
@@ -1,0 +1,119 @@
+{
+	"info": {
+		"_postman_id": "b3069366-28b0-4432-bc4e-eddb43daeeb4",
+		"name": "Strip Alphanumerics Test",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "18475687"
+	},
+	"item": [
+		{
+			"name": "Get by ID",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{baseUrl}}/users/123",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"users",
+						"123"
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "Get by ID",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/456",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								"456"
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json",
+							"description": "",
+							"type": "text"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"id\" : {{$randomInt}},\n    \"name\" : \"456\"\n}"
+				},
+				{
+					"name": "Get by ID with trailing slash",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/users/456/",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"users",
+								"456",
+								""
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json",
+							"description": "",
+							"type": "text"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"id\" : {{$randomInt}},\n    \"name\" : \"456\"\n}"
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "baseUrl",
+			"value": "",
+			"type": "string"
+		}
+	]
+}

--- a/test/distanceTest.js
+++ b/test/distanceTest.js
@@ -1,0 +1,51 @@
+const fs = require('fs')
+const PostmanLocalMockServer = require('../index.js')
+const axios = require('axios').default
+const assert = require('assert')
+
+const PORT = 3561;
+
+var options = {
+    port: PORT,
+    debug: true
+}
+
+let server
+
+describe('Document Distance Tests', () => {
+    beforeEach(() => {
+        options.collection = JSON.parse(
+            fs.readFileSync('./test/collections/document-distance-tests.json', 'utf8')
+        )
+
+        server = new PostmanLocalMockServer(options)
+        server.start()
+    })
+
+    it('Perfect Match', async () => {
+        return await axios
+            .get(
+                `http://localhost:${PORT}/documents/my-document`
+            )
+            .then(res => res.data)
+            .then(res => {
+                assert(res.status === "perfect match")
+            })
+    })
+
+    it('Near Match', async () => {
+        return await axios
+            .get(
+                `http://localhost:${PORT}/employees/caroline`
+            )
+            .then(res => res.data)
+            .then(res => {
+                assert(res.status === "near match")
+            })
+    })
+
+
+    afterEach(() => {
+        server.stop()
+    })
+});

--- a/test/requestTypesTest.js
+++ b/test/requestTypesTest.js
@@ -3,7 +3,7 @@ const PostmanLocalMockServer = require('../index.js')
 const axios = require('axios').default
 const assert = require('assert')
 
-const PORT = 3555;
+const PORT = 3556;
 
 var options = {
   port: PORT,

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -3,7 +3,7 @@ const PostmanLocalMockServer = require('../index.js')
 const axios = require('axios').default
 const assert = require('assert')
 
-const PORT = 3000;
+const PORT = 3557;
 
 var options = {
   port: PORT,

--- a/test/stripAlphanumericsTest.js
+++ b/test/stripAlphanumericsTest.js
@@ -1,0 +1,68 @@
+const fs = require('fs')
+const PostmanLocalMockServer = require('../index.js')
+const axios = require('axios').default
+const assert = require('assert')
+
+const PORT = 3558;
+
+var options = {
+    port: PORT,
+    debug: true
+}
+
+let server
+
+describe('Strip Alphanumerics Tests', () => {
+    beforeEach(() => {
+        options.collection = JSON.parse(
+            fs.readFileSync('./test/collections/strip-alpha-tests.json', 'utf8')
+        )
+
+        server = new PostmanLocalMockServer(options)
+        server.start()
+    })
+
+    describe('Default request tests', () => {
+        it('Should match with a different numeric ID', async () => {
+            return await axios.get(`http://localhost:${PORT}/users/123`).then(res => {
+                assert(res.data.name === '456')
+            })
+        })
+
+        it('Should match with a different UUID', async () => {
+            return await axios.get(`http://localhost:${PORT}/users/13debaf5-53ed-4a85-8ee3-d47258ce1078`).then(res => {
+                assert(res.data.name === '456')
+            })
+        })
+
+        //string of 300 chars
+        let largestring = "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
+
+        it('Should match with a large string', async () => {
+            return await axios.get(`http://localhost:${PORT}/users/${largestring}`).then(res => {
+                assert(res.data.name === '456')
+            })
+        })
+
+        it('Should match with a different numeric ID and a trailing slash', async () => {
+            return await axios.get(`http://localhost:${PORT}/users/123/`).then(res => {
+                assert(res.data.name === '456')
+            })
+        })
+
+        it('Should not match with a text ID', async () => {
+            return await axios.get(`http://localhost:${PORT}/users/carol`)
+                .then(res => {
+                    //This should not work
+                    assert(1 == 2);
+                })
+                .catch(err => {
+                    assert(err.response.status === 404)
+                })
+        })
+    })
+
+    afterEach(() => {
+        server.stop()
+    })
+});

--- a/test/tlsServerTest.js
+++ b/test/tlsServerTest.js
@@ -4,7 +4,7 @@ const PostmanLocalMockServer = require('../index.js')
 const axios = require('axios').default
 const assert = require('assert')
 
-const PORT = 3555;
+const PORT = 3559;
 
 var options = {
   port: PORT,

--- a/test/wildcardVariablesTest.js
+++ b/test/wildcardVariablesTest.js
@@ -3,7 +3,7 @@ const PostmanLocalMockServer = require('../index.js')
 const axios = require('axios').default
 const assert = require('assert')
 
-const PORT = 3000;
+const PORT = 3560;
 
 var options = {
   port: PORT,


### PR DESCRIPTION
This PR adds the final check to match Postman's mock matching algorithm - the Levenshtein distance calculations.

Any request that is sent to a mock server that does not contain any `x-mock` selectors, and also does not match any of the other response categories (e.g. by URL, query parameters, body etc) should have a distance check performed.

The goal here is to catch cases where there are typos in the URL. E.g. `/users/caroline -> /users/carolyne` should match.

The algorithm will look at each part of the URL and validate that it is at least a 75% match. If all parts are at least this match, then this response will be selected as the best match (as a last resort).