### PR TITLE
Fix/error with no path

### DIFF
--- a/lib/responses.js
+++ b/lib/responses.js
@@ -72,10 +72,12 @@ function getMatchedResponse(req, responses, debug) {
             score: 100
         };
 
+        let thisResponsePath = "";
+
         //get the path for this response.
-        let thisResponsePath = `${response.originalRequest.url.path.join(
-            '/'
-        )}`
+        if(response && response.originalRequest && response.originalRequest.url && response.originalRequest.url.path) {
+            thisResponsePath = `${response.originalRequest.url.path.join('/')}`
+        }
 
         //3.1.1 Perfect Score
         debug && console.log(`Perfect Match: ${req.path} eq /${thisResponsePath}`, _.isEqual(req.path, `/${thisResponsePath}`))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jordanwalsh23/postman-local-mock-server",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jordanwalsh23/postman-local-mock-server",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jordanwalsh23/postman-local-mock-server",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Provides the ability to run Postman collections as a local mock server.",
   "main": "index.js",
   "scripts": {

--- a/test/collections/test-collection-no-path.json
+++ b/test/collections/test-collection-no-path.json
@@ -1,0 +1,52 @@
+{
+	"info": {
+		"_postman_id": "39a1d6e2-8a17-436b-886c-f87c3b2f1248",
+		"name": "Test Request with No Path",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "18475687"
+	},
+	"item": [
+		{
+			"name": "No Path",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{baseUrl}}",
+					"host": [
+						"{{baseUrl}}"
+					]
+				}
+			},
+			"response": [
+				{
+					"name": "No Path",
+					"originalRequest": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}",
+							"host": [
+								"{{baseUrl}}"
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json",
+							"name": "Content-Type",
+							"description": "",
+							"type": "text"
+						}
+					],
+					"cookie": [],
+					"body": "{\n    \"status\": \"OK\"\n}"
+				}
+			]
+		}
+	]
+}

--- a/test/noPathTest.js
+++ b/test/noPathTest.js
@@ -1,0 +1,36 @@
+const fs = require('fs')
+const PostmanLocalMockServer = require('../index.js')
+const axios = require('axios').default
+const assert = require('assert')
+
+const PORT = 3561;
+
+var options = {
+  port: PORT,
+  debug: true
+}
+
+let server
+
+describe('Postman Local Mock Server Tests', () => {
+  beforeEach(() => {
+    options.collection = JSON.parse(
+      fs.readFileSync('./test/collections/test-collection-no-path.json', 'utf8')
+    )
+
+    server = new PostmanLocalMockServer(options)
+    server.start()
+  })
+
+  describe('Get with no path', () => {
+    it('Default GET response test with no path', async () => {
+      return await axios.get(`http://localhost:${PORT}`).then(res => {
+        assert(res.data.status === 'OK')
+      })
+    })
+  })
+
+  afterEach(() => {
+    server.stop()
+  })
+});


### PR DESCRIPTION
Fixes an issue where if the collection has no path it was throwing an error:

<img width="1705" alt="image" src="https://github.com/user-attachments/assets/11720b04-cd0e-4098-9c42-d367342f896b">
