### PR TITLE
chore(enhancement): query param value matches on decodedURI value set

### DIFF
--- a/lib/responses.js
+++ b/lib/responses.js
@@ -1,7 +1,7 @@
 const _ = require('lodash')
 const distance = require('fastest-levenshtein').distance
 
-function getMatchedResponse(req, responses, debug) {
+function getMatchedResponse(req, responses, debug) { 
     var bestMatchedResponse = null;
     var bestMatchedResponseScore = 0;
 
@@ -15,7 +15,7 @@ function getMatchedResponse(req, responses, debug) {
     if (responsesToProcess.length == 0) {
         return;
     }
-
+  
     //2. Filter on Custom Mock Server Headers
     //Check and see if any of the mock response selectors were used
     let postmanHeaders = [
@@ -60,7 +60,7 @@ function getMatchedResponse(req, responses, debug) {
             return matchedPostmanHeadersResponse;
         }
     }
-
+   
     //3. Filter by URL
     debug && console.log('scoring responses by URL match...')
 
@@ -183,37 +183,77 @@ function getMatchedResponse(req, responses, debug) {
         //iterate through the results array as these are the only potential matches.
         Object.keys(results).forEach((id) => {
 
-            let response = responsesToProcess.find(response => response.id == id);
-            debug && console.log('Scoring query parameters')
+            let response = responsesToProcess.find(
+                (response) => response.id == id
+            );
+            debug && console.log("Scoring query parameters");
             let fullMatches = 0;
             let partialMatches = 0;
             let missingMatches = 0;
             let totalQueryParams = Object.keys(req.query).length;
 
-            Object.keys(req.query).every((key) => {
+            let kv = new Map();
+            const responseHasQueryMember =
+                response.originalRequest &&
+                response.originalRequest.url &&
+                response.originalRequest.url.query &&
+                response.originalRequest.url.query.members &&
+                Array.isArray(response.originalRequest.url.query.members);
 
-                if (
-                    response.originalRequest &&
-                    response.originalRequest.url &&
-                    response.originalRequest.url.query &&
-                    response.originalRequest.url.query.members &&
-                    Array.isArray(response.originalRequest.url.query.members)
-                ) {
-                    let matchKeyAndValue =
-                        response.originalRequest.url.query.find(param => {
-                            return key == param.key && req.query[key] == param.value
-                        })
+            if (responseHasQueryMember) {
+                for (const param of response.originalRequest.url.query
+                    .members) {
+                    if (kv.has(param.key)) {
+                        const values = kv.get(param.key);
+                        if (Array.isArray(param.value)) {
+                            for (const value of param.value) {
+                                values.push(decodeURI(value));
+                            }
+                        } else {
+                            values.push(decodeURI(param.value));
+                        }
+                    } else {
+                        const values = [];
+                        if (Array.isArray(param.value)) {
+                            for (const value of param.value) {
+                                values.push(decodeURI(value));
+                            }
+                        } else {
+                            values.push(decodeURI(param.value));
+                        }
+                        kv.set(param.key, values);
+                    }
+                }
+            }
+
+            Object.keys(req.query).every((key) => {
+                if (responseHasQueryMember) {
+                    const queryValueSet = new Set();
+                    if (Array.isArray(req.query[key])) {
+                        for (const value of req.query[key]) {
+                            queryValueSet.add(decodeURI(value));
+                        }
+                    } else {
+                        queryValueSet.add(decodeURI(req.query[key]));
+                    }
+
+                    const matchKeyAndValue = kv
+                        .get(key)
+                        ?.every((value) => queryValueSet.has(value));
 
                     if (matchKeyAndValue) {
+                        debug && console.log("key and value match");
                         //We found a matched query and value so increase the score.
                         fullMatches++;
                         return true;
                     }
 
-                    let match = response.originalRequest.url.query.find(param => {
-                        debug && console.log("key:" + key.toLowerCase(), "param key: ", param.key.toLowerCase())
-                        return key.toLowerCase() == param.key.toLowerCase()
-                    })
+                    let match = response.originalRequest.url.query.members.find(
+                        (param) => {
+                            debug && console.log("key:" + key.toLowerCase(),"param key: ",param.key.toLowerCase());
+                            return key.toLowerCase() == param.key.toLowerCase();
+                        }
+                    );
 
                     if (match) {
                         //We found a matched query key so increase the score.
@@ -223,15 +263,17 @@ function getMatchedResponse(req, responses, debug) {
                         missingMatches++;
                         return true;
                     }
-
                 } else {
-                    debug && console.log('No query parameters on this response example.')
+                    debug &&
+                        console.log(
+                            "No query parameters on this response example."
+                        );
                 }
             });
 
             let matchingPct = parseFloat(fullMatches / (fullMatches + partialMatches + missingMatches));
             debug && console.log(`matchingpct: ${matchingPct}.`, fullMatches, partialMatches, missingMatches, totalQueryParams);
-            debug && console.log(fullMatches == totalQueryParams)
+            debug && console.log(`isallMatch`,fullMatches == totalQueryParams)
 
             debug && console.log("results score before: ", results[id].score)
 

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -205,21 +205,30 @@ function getMatchedResponse(req, responses, debug) {
                     .members) {
                     if (kv.has(param.key)) {
                         const values = kv.get(param.key);
+                        
                         if (Array.isArray(param.value)) {
-                            for (const value of param.value) {
-                                values.push(decodeURI(value));
+                            for (const values of param.value) {
+                                for (const value of values.split(',')) {
+                                    values.push(decodeURI(value));
+                                }
                             }
                         } else {
-                            values.push(decodeURI(param.value));
+                            for (const value of param.value.split(',')) {
+                                values.push(decodeURI(value));
+                            }
                         }
                     } else {
                         const values = [];
                         if (Array.isArray(param.value)) {
-                            for (const value of param.value) {
-                                values.push(decodeURI(value));
+                            for (const values of param.value) {
+                                for (const value of values.split(',')) {
+                                    values.push(decodeURI(value));
+                                }
                             }
                         } else {
-                            values.push(decodeURI(param.value));
+                            for (const value of param.value.split(',')) {
+                                values.push(decodeURI(value));
+                            }
                         }
                         kv.set(param.key, values);
                     }

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -201,37 +201,31 @@ function getMatchedResponse(req, responses, debug) {
                 Array.isArray(response.originalRequest.url.query.members);
 
             if (responseHasQueryMember) {
+                const decodeAndSplit = (value) =>
+                    value.split(",").map(decodeURI);
+
+                /**
+                 * Iterate through the query parameters and check the following:
+                 *
+                 * 1. if param is disabled, skip it
+                 * 2. If we have already processed a query param with this key - retrieve the value, else return an empty array.
+                 * 3. Evaluate the current param value
+                 * 3.1. If the param value is an array, flatten each item of the array and return the decoded version.
+                 * 3.2. If the param value is not an array, return the decoded version.
+                 * 4. Update the value in the Key/Value Map.
+                 */
+
                 for (const param of response.originalRequest.url.query
                     .members) {
-                    if (kv.has(param.key)) {
-                        const values = kv.get(param.key);
-                        
-                        if (Array.isArray(param.value)) {
-                            for (const values of param.value) {
-                                for (const value of values.split(',')) {
-                                    values.push(decodeURI(value));
-                                }
-                            }
-                        } else {
-                            for (const value of param.value.split(',')) {
-                                values.push(decodeURI(value));
-                            }
-                        }
-                    } else {
-                        const values = [];
-                        if (Array.isArray(param.value)) {
-                            for (const values of param.value) {
-                                for (const value of values.split(',')) {
-                                    values.push(decodeURI(value));
-                                }
-                            }
-                        } else {
-                            for (const value of param.value.split(',')) {
-                                values.push(decodeURI(value));
-                            }
-                        }
-                        kv.set(param.key, values);
+                    if (param.disabled) {
+                        continue;
                     }
+
+                    const existingValues = kv.get(param.key) || [];
+                    const thisParamValues = Array.isArray(param.value)
+                        ? param.value.flatMap(decodeAndSplit)
+                        : decodeAndSplit(param.value);
+                    kv.set(param.key, existingValues.concat(thisParamValues));
                 }
             }
 
@@ -248,7 +242,7 @@ function getMatchedResponse(req, responses, debug) {
 
                     const matchKeyAndValue = kv
                         .get(key)
-                        ?.every((value) => queryValueSet.has(value));
+                        ?.every((value) => queryValueSet.has(value)) ?? false;
 
                     if (matchKeyAndValue) {
                         debug && console.log("key and value match");

--- a/test/collections/all-request-types.json
+++ b/test/collections/all-request-types.json
@@ -1,444 +1,723 @@
 {
-	"info": {
-		"_postman_id": "e4fd5868-3fa0-4a24-bd9b-cd9500e0ea64",
-		"name": "All request types",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "18475687"
-	},
-	"item": [
-		{
-			"name": "GET Request",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "https://postman-echo.com/get",
-					"protocol": "https",
-					"host": [
-						"postman-echo",
-						"com"
-					],
-					"path": [
-						"get"
-					]
-				}
-			},
-			"response": [
-				{
-					"name": "Success",
-					"originalRequest": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "https://postman-echo.com/get",
-							"protocol": "https",
-							"host": [
-								"postman-echo",
-								"com"
-							],
-							"path": [
-								"get"
-							]
-						}
-					},
-					"status": "OK",
-					"code": 200,
-					"_postman_previewlanguage": "json",
-					"header": [
-						{
-							"key": "Date",
-							"value": "Thu, 23 Nov 2023 23:33:33 GMT"
-						},
-						{
-							"key": "Content-Type",
-							"value": "application/json; charset=utf-8"
-						},
-						{
-							"key": "Content-Length",
-							"value": "442"
-						},
-						{
-							"key": "Connection",
-							"value": "keep-alive"
-						},
-						{
-							"key": "ETag",
-							"value": "W/\"1ba-Y9P2R1aI4nnJ8nqHUJ8AYbFZn9M\""
-						},
-						{
-							"key": "set-cookie",
-							"value": "sails.sid=s%3Akjl66_MYnofvGLeQK9R6H6WE3H6Fnq3e.4MIND71UoLG2S%2BvLQatbVFrxMEo%2BG1APYBx6%2B50vpUI; Path=/; HttpOnly"
-						}
-					],
-					"cookie": [],
-					"body": "{\n    \"args\": {},\n    \"headers\": {\n        \"x-forwarded-proto\": \"https\",\n        \"x-forwarded-port\": \"443\",\n        \"host\": \"postman-echo.com\",\n        \"x-amzn-trace-id\": \"Root=1-655fe14d-28b9d53f65bb55b309305cdc\",\n        \"user-agent\": \"PostmanRuntime/7.34.0\",\n        \"accept\": \"*/*\",\n        \"cache-control\": \"no-cache\",\n        \"postman-token\": \"134cbbfb-fb0d-4d17-8345-8add3dda36ff\",\n        \"accept-encoding\": \"gzip, deflate, br\"\n    },\n    \"url\": \"https://postman-echo.com/get\"\n}"
-				}
-			]
-		},
-		{
-			"name": "POST Request",
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"status\": true\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "https://postman-echo.com/post",
-					"protocol": "https",
-					"host": [
-						"postman-echo",
-						"com"
-					],
-					"path": [
-						"post"
-					]
-				}
-			},
-			"response": [
-				{
-					"name": "Success",
-					"originalRequest": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"status\": true\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "https://postman-echo.com/post",
-							"protocol": "https",
-							"host": [
-								"postman-echo",
-								"com"
-							],
-							"path": [
-								"post"
-							]
-						}
-					},
-					"status": "OK",
-					"code": 200,
-					"_postman_previewlanguage": "json",
-					"header": [
-						{
-							"key": "Date",
-							"value": "Thu, 23 Nov 2023 23:34:07 GMT"
-						},
-						{
-							"key": "Content-Type",
-							"value": "application/json; charset=utf-8"
-						},
-						{
-							"key": "Content-Length",
-							"value": "726"
-						},
-						{
-							"key": "Connection",
-							"value": "keep-alive"
-						},
-						{
-							"key": "ETag",
-							"value": "W/\"2d6-nRABG6UoarONIL57wK8T/BmID2M\""
-						}
-					],
-					"cookie": [],
-					"body": "{\n    \"args\": {},\n    \"data\": {\n        \"status\": true\n    },\n    \"files\": {},\n    \"form\": {},\n    \"headers\": {\n        \"x-forwarded-proto\": \"https\",\n        \"x-forwarded-port\": \"443\",\n        \"host\": \"postman-echo.com\",\n        \"x-amzn-trace-id\": \"Root=1-655fe16f-20f0e5486467995a5336ccbf\",\n        \"content-length\": \"22\",\n        \"content-type\": \"application/json\",\n        \"user-agent\": \"PostmanRuntime/7.34.0\",\n        \"accept\": \"*/*\",\n        \"cache-control\": \"no-cache\",\n        \"postman-token\": \"f99dd15a-1cc0-44e5-bbdd-f66749bdb7ed\",\n        \"accept-encoding\": \"gzip, deflate, br\",\n        \"cookie\": \"sails.sid=s%3Akjl66_MYnofvGLeQK9R6H6WE3H6Fnq3e.4MIND71UoLG2S%2BvLQatbVFrxMEo%2BG1APYBx6%2B50vpUI\"\n    },\n    \"json\": {\n        \"status\": true\n    },\n    \"url\": \"https://postman-echo.com/post\"\n}"
-				}
-			]
-		},
-		{
-			"name": "PUT Request",
-			"request": {
-				"method": "PUT",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"status\": true\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "https://postman-echo.com/put",
-					"protocol": "https",
-					"host": [
-						"postman-echo",
-						"com"
-					],
-					"path": [
-						"put"
-					]
-				}
-			},
-			"response": [
-				{
-					"name": "Success",
-					"originalRequest": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"status\": true\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "https://postman-echo.com/put",
-							"protocol": "https",
-							"host": [
-								"postman-echo",
-								"com"
-							],
-							"path": [
-								"put"
-							]
-						}
-					},
-					"status": "OK",
-					"code": 200,
-					"_postman_previewlanguage": "json",
-					"header": [
-						{
-							"key": "Date",
-							"value": "Thu, 23 Nov 2023 23:36:46 GMT"
-						},
-						{
-							"key": "Content-Type",
-							"value": "application/json; charset=utf-8"
-						},
-						{
-							"key": "Content-Length",
-							"value": "719"
-						},
-						{
-							"key": "Connection",
-							"value": "keep-alive"
-						},
-						{
-							"key": "ETag",
-							"value": "W/\"2cf-i+NvahouosJ1Dtm87c4y2+o+3a4\""
-						},
-						{
-							"key": "set-cookie",
-							"value": "sails.sid=s%3A-wgwzsNHA0eCYjoyXe_dt4dpIwtHnK4i.4orK5GgxoSkplKt9UetjgHCq6zS5pPr7HPOX0PbOink; Path=/; HttpOnly"
-						}
-					],
-					"cookie": [],
-					"body": "{\n    \"args\": {},\n    \"data\": {\n        \"status\": true\n    },\n    \"files\": {},\n    \"form\": {},\n    \"headers\": {\n        \"x-forwarded-proto\": \"https\",\n        \"x-forwarded-port\": \"443\",\n        \"host\": \"postman-echo.com\",\n        \"x-amzn-trace-id\": \"Root=1-655fe20e-4b25156f72bcac4e0a371039\",\n        \"content-length\": \"22\",\n        \"content-type\": \"application/json\",\n        \"user-agent\": \"PostmanRuntime/7.34.0\",\n        \"accept\": \"*/*\",\n        \"cache-control\": \"no-cache\",\n        \"postman-token\": \"5a9f83b3-e23e-4508-a2f4-e885334b3fa4\",\n        \"accept-encoding\": \"gzip, deflate, br\",\n        \"cookie\": \"sails.sid=s%3Asl1wvDCjbgiBUeMu2rCuHaI51P4I8nU1.ivUzpXb7CulF2HqsVUstx19a0SwEVzaz5SHfNeSGIbk\"\n    },\n    \"json\": {\n        \"status\": true\n    },\n    \"url\": \"https://postman-echo.com/put\"\n}"
-				}
-			]
-		},
-		{
-			"name": "DELETE Request",
-			"request": {
-				"method": "DELETE",
-				"header": [],
-				"url": {
-					"raw": "https://postman-echo.com/delete",
-					"protocol": "https",
-					"host": [
-						"postman-echo",
-						"com"
-					],
-					"path": [
-						"delete"
-					]
-				}
-			},
-			"response": [
-				{
-					"name": "Success",
-					"originalRequest": {
-						"method": "DELETE",
-						"header": [],
-						"url": {
-							"raw": "https://postman-echo.com/delete",
-							"protocol": "https",
-							"host": [
-								"postman-echo",
-								"com"
-							],
-							"path": [
-								"delete"
-							]
-						}
-					},
-					"status": "OK",
-					"code": 200,
-					"_postman_previewlanguage": "json",
-					"header": [
-						{
-							"key": "Date",
-							"value": "Thu, 23 Nov 2023 23:37:21 GMT"
-						},
-						{
-							"key": "Content-Type",
-							"value": "application/json; charset=utf-8"
-						},
-						{
-							"key": "Content-Length",
-							"value": "652"
-						},
-						{
-							"key": "Connection",
-							"value": "keep-alive"
-						},
-						{
-							"key": "ETag",
-							"value": "W/\"28c-nQgALfAv+CVFam3i53BvxOVU54E\""
-						},
-						{
-							"key": "set-cookie",
-							"value": "sails.sid=s%3ATR_hIReC-F2rqdLWqT-LBzbobzIpl9Kk.XQacX6N3J5EErxiFtCSSOQP9XaXQ%2BLskN29Cg2mW448; Path=/; HttpOnly"
-						}
-					],
-					"cookie": [],
-					"body": "{\n    \"args\": {},\n    \"data\": {},\n    \"files\": {},\n    \"form\": {},\n    \"headers\": {\n        \"x-forwarded-proto\": \"https\",\n        \"x-forwarded-port\": \"443\",\n        \"host\": \"postman-echo.com\",\n        \"x-amzn-trace-id\": \"Root=1-655fe231-7a391f7e27bfc74b490c454a\",\n        \"user-agent\": \"PostmanRuntime/7.34.0\",\n        \"accept\": \"*/*\",\n        \"cache-control\": \"no-cache\",\n        \"postman-token\": \"89ffbbd1-7ab8-44e8-9e30-b17a217f7842\",\n        \"accept-encoding\": \"gzip, deflate, br\",\n        \"cookie\": \"sails.sid=s%3A-wgwzsNHA0eCYjoyXe_dt4dpIwtHnK4i.4orK5GgxoSkplKt9UetjgHCq6zS5pPr7HPOX0PbOink\",\n        \"content-type\": \"application/json\"\n    },\n    \"json\": null,\n    \"url\": \"https://postman-echo.com/delete\"\n}"
-				}
-			]
-		},
-		{
-			"name": "HEAD Request",
-			"request": {
-				"method": "HEAD",
-				"header": [],
-				"url": {
-					"raw": "https://postman-echo.com/head",
-					"protocol": "https",
-					"host": [
-						"postman-echo",
-						"com"
-					],
-					"path": [
-						"head"
-					]
-				}
-			},
-			"response": [
-				{
-					"name": "Success",
-					"originalRequest": {
-						"method": "HEAD",
-						"header": [],
-						"url": {
-							"raw": "https://postman-echo.com/head",
-							"protocol": "https",
-							"host": [
-								"postman-echo",
-								"com"
-							],
-							"path": [
-								"head"
-							]
-						}
-					},
-					"status": "OK",
-					"code": 200,
-					"_postman_previewlanguage": "plain",
-					"header": [
-						{
-							"key": "Date",
-							"value": "Thu, 23 Nov 2023 23:37:59 GMT"
-						},
-						{
-							"key": "Connection",
-							"value": "keep-alive"
-						},
-						{
-							"key": "set-cookie",
-							"value": "sails.sid=s%3An4fodz5ejHvaaQIkrd3-PTxp5hfkz4NW.miVyQ0Pn%2B%2FzrVWcbTX28acahHGuG7eOjxVExQCtDHeU; Path=/; HttpOnly"
-						}
-					],
-					"cookie": [],
-					"body": null
-				}
-			]
-		},
-		{
-			"name": "OPTIONS Request",
-			"request": {
-				"method": "OPTIONS",
-				"header": [],
-				"url": {
-					"raw": "https://postman-echo.com/options",
-					"protocol": "https",
-					"host": [
-						"postman-echo",
-						"com"
-					],
-					"path": [
-						"options"
-					]
-				}
-			},
-			"response": [
-				{
-					"name": "Success",
-					"originalRequest": {
-						"method": "OPTIONS",
-						"header": [],
-						"url": {
-							"raw": "https://postman-echo.com/options",
-							"protocol": "https",
-							"host": [
-								"postman-echo",
-								"com"
-							],
-							"path": [
-								"options"
-							]
-						}
-					},
-					"status": "OK",
-					"code": 200,
-					"_postman_previewlanguage": "plain",
-					"header": [
-						{
-							"key": "Date",
-							"value": "Thu, 23 Nov 2023 23:38:22 GMT"
-						},
-						{
-							"key": "Content-Length",
-							"value": "0"
-						},
-						{
-							"key": "Connection",
-							"value": "keep-alive"
-						},
-						{
-							"key": "Access-Control-Allow-Origin",
-							"value": "*"
-						},
-						{
-							"key": "Allow",
-							"value": "OPTIONS"
-						},
-						{
-							"key": "set-cookie",
-							"value": "sails.sid=s%3AcGeFU9Va5a1xKzR9pT8XTKkX7geM0WqK.Gjq7ZLYkM7MNWoYgIUZO8He8ynV7qYJAtJmCl%2BrNuzQ; Path=/; HttpOnly"
-						}
-					],
-					"cookie": [],
-					"body": null
-				}
-			]
-		}
-	]
+  "info": {
+    "_postman_id": "e4fd5868-3fa0-4a24-bd9b-cd9500e0ea64",
+    "name": "All request types",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "18475687"
+  },
+  "item": [
+    {
+      "name": "GET request with query param with 1 id",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "https://postman-echo.com/users?page=1&limit=1&filters=id%20in%20(05ee1e2d-1a80-4384-9d65-3beb16bcfd1a)&filters=company_id%20eq%202",
+          "protocol": "https",
+          "host": [
+            "postman-echo",
+            "com"
+          ],
+          "path": [
+            "users"
+          ],
+          "query": [
+            {
+              "key": "page",
+              "value": "1"
+            },
+            {
+              "key": "limit",
+              "value": "1"
+            },
+            {
+              "key": "filters",
+              "value": "id%20in%20(05ee1e2d-1a80-4384-9d65-3beb16bcfd1a)"
+            },
+            {
+              "key": "filters",
+              "value": "company_id%20eq%202"
+            }
+          ]
+        }
+      },
+      "response": {
+        "name": "Success to get users with id 05ee1e2d-1a80-4384-9d65-3beb16bcfd1a",
+        "originalRequest": {
+          "method": "GET",
+          "header": [
+            {
+              "key": "Accept",
+              "value": "application/json"
+            }
+          ],
+          "url": {
+            "raw": "https://postman-echo.com/users?page=1&limit=1&filters=id%20in%20(05ee1e2d-1a80-4384-9d65-3beb16bcfd1a),company_id%20eq%202",
+            "protocol": "https",
+            "host": [
+              "postman-echo",
+              "com"
+            ],
+            "path": [
+              "users"
+            ],
+            "query": [
+              {
+                "key": "page",
+                "value": "1"
+              },
+              {
+                "key": "limit",
+                "value": "1"
+              },
+              {
+                "key": "filters",
+                "value": "id%20in%20(05ee1e2d-1a80-4384-9d65-3beb16bcfd1a)"
+              },
+              {
+                "key": "filters",
+                "value": "company_id%20eq%202"
+              }
+            ]
+          }
+        },
+        "status": "OK",
+        "code": 200,
+        "_postman_previewlanguage": "json",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "cookie": [],
+        "body": "{\"metadata\": {\"page\":1, \"count\":1, \"total_page\":1, \"total_count\":1}, \"data\": {\"ids\": [\"05ee1e2d-1a80-4384-9d65-3beb16bcfd1a\"]}}"
+      }
+    },
+    {
+      "name": "GET request with query param with id 9c366ded-4c52-43ed-ab73-db7566f28132 8810022b-1fe9-40fb-bd5b-cfb48beaa621",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "https://postman-echo.com/users?page=1&limit=2&filters=id%20in%20(9c366ded-4c52-43ed-ab73-db7566f28132%208810022b-1fe9-40fb-bd5b-cfb48beaa621)&filters=company_id%20eq%202",
+          "protocol": "https",
+          "host": [
+            "postman-echo",
+            "com"
+          ],
+          "path": [
+            "users"
+          ],
+          "query": [
+            {
+              "key": "page",
+              "value": "1"
+            },
+            {
+              "key": "limit",
+              "value": "2"
+            },
+            {
+              "key": "filters",
+              "value": "id%20in%20(9c366ded-4c52-43ed-ab73-db7566f28132%208810022b-1fe9-40fb-bd5b-cfb48beaa621)"
+            },
+            {
+              "key": "filters",
+              "value": "company_id%20eq%202"
+            }
+          ]
+        }
+      },
+      "response": {
+        "name": "Success to get users with id 9c366ded-4c52-43ed-ab73-db7566f28132 and 8810022b-1fe9-40fb-bd5b-cfb48beaa621",
+        "originalRequest": {
+          "method": "GET",
+          "header": [
+            {
+              "key": "Accept",
+              "value": "application/json"
+            }
+          ],
+          "url": {
+            "raw": "https://postman-echo.com/users?page=1&limit=2&filters=id%20in%20(9c366ded-4c52-43ed-ab73-db7566f28132%208810022b-1fe9-40fb-bd5b-cfb48beaa621)&filters=company_id%20eq%202",
+            "protocol": "https",
+            "host": [
+              "postman-echo",
+              "com"
+            ],
+            "path": [
+              "users"
+            ],
+            "query": [
+              {
+                "key": "page",
+                "value": "1"
+              },
+              {
+                "key": "limit",
+                "value": "2"
+              },
+              {
+                "key": "filters",
+                "value": "id%20in%20(9c366ded-4c52-43ed-ab73-db7566f28132%208810022b-1fe9-40fb-bd5b-cfb48beaa621)"
+              },
+              {
+                "key": "filters",
+                "value": "company_id%20eq%202"
+              }
+            ]
+          }
+        },
+        "status": "OK",
+        "code": 200,
+        "_postman_previewlanguage": "json",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "cookie": [],
+        "body": "{\"metadata\": {\"page\":1, \"count\":2, \"total_page\":1, \"total_count\":2}, \"data\": {\"ids\": [\"9c366ded-4c52-43ed-ab73-db7566f28132\",\"8810022b-1fe9-40fb-bd5b-cfb48beaa621\"]}}"
+      }
+    },
+    {
+      "name": "GET request with query param with id 05ee1e2d-1a80-4384-9d65-3beb16bcfd1a 8810022b-1fe9-40fb-bd5b-cfb48beaa621",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "https://postman-echo.com/users?page=1&limit=2&filters=id%20in%20(05ee1e2d-1a80-4384-9d65-3beb16bcfd1a%208810022b-1fe9-40fb-bd5b-cfb48beaa621)&filters=company_id%20eq%202",
+          "protocol": "https",
+          "host": [
+            "postman-echo",
+            "com"
+          ],
+          "path": [
+            "users"
+          ],
+          "query": [
+            {
+              "key": "page",
+              "value": "1"
+            },
+            {
+              "key": "limit",
+              "value": "2"
+            },
+            {
+              "key": "filters",
+              "value": "id%20in%20(05ee1e2d-1a80-4384-9d65-3beb16bcfd1a%208810022b-1fe9-40fb-bd5b-cfb48beaa621)"
+            },
+            {
+              "key": "filters",
+              "value": "company_id%20eq%202"
+            }
+          ]
+        }
+      },
+      "response": {
+        "name": "Success to get users with id 05ee1e2d-1a80-4384-9d65-3beb16bcfd1a and 8810022b-1fe9-40fb-bd5b-cfb48beaa621",
+        "originalRequest": {
+          "method": "GET",
+          "header": [
+            {
+              "key": "Accept",
+              "value": "application/json"
+            }
+          ],
+          "url": {
+            "raw": "https://postman-echo.com/users?page=1&limit=2&filters=id%20in%20(05ee1e2d-1a80-4384-9d65-3beb16bcfd1a%208810022b-1fe9-40fb-bd5b-cfb48beaa621)&filters=company_id%20eq%202",
+            "protocol": "https",
+            "host": [
+              "postman-echo",
+              "com"
+            ],
+            "path": [
+              "users"
+            ],
+            "query": [
+              {
+                "key": "page",
+                "value": "1"
+              },
+              {
+                "key": "limit",
+                "value": "2"
+              },
+              {
+                "key": "filters",
+                "value": "id%20in%20(05ee1e2d-1a80-4384-9d65-3beb16bcfd1a%208810022b-1fe9-40fb-bd5b-cfb48beaa621)"
+              },
+              {
+                "key": "filters",
+                "value": "company_id%20eq%202"
+              }
+            ]
+          }
+        },
+        "status": "OK",
+        "code": 200,
+        "_postman_previewlanguage": "json",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "cookie": [],
+        "body": "{\"metadata\": {\"page\":1, \"count\":2, \"total_page\":1, \"total_count\":2}, \"data\": {\"ids\": [\"05ee1e2d-1a80-4384-9d65-3beb16bcfd1a\",\"8810022b-1fe9-40fb-bd5b-cfb48beaa621\"]}}"
+      }
+    },
+    {
+      "name": "GET Request",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "https://postman-echo.com/get",
+          "protocol": "https",
+          "host": [
+            "postman-echo",
+            "com"
+          ],
+          "path": [
+            "get"
+          ]
+        }
+      },
+      "response": [
+        {
+          "name": "Success",
+          "originalRequest": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "https://postman-echo.com/get",
+              "protocol": "https",
+              "host": [
+                "postman-echo",
+                "com"
+              ],
+              "path": [
+                "get"
+              ]
+            }
+          },
+          "status": "OK",
+          "code": 200,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "Date",
+              "value": "Thu, 23 Nov 2023 23:33:33 GMT"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "442"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"1ba-Y9P2R1aI4nnJ8nqHUJ8AYbFZn9M\""
+            },
+            {
+              "key": "set-cookie",
+              "value": "sails.sid=s%3Akjl66_MYnofvGLeQK9R6H6WE3H6Fnq3e.4MIND71UoLG2S%2BvLQatbVFrxMEo%2BG1APYBx6%2B50vpUI; Path=/; HttpOnly"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"args\": {},\n    \"headers\": {\n        \"x-forwarded-proto\": \"https\",\n        \"x-forwarded-port\": \"443\",\n        \"host\": \"postman-echo.com\",\n        \"x-amzn-trace-id\": \"Root=1-655fe14d-28b9d53f65bb55b309305cdc\",\n        \"user-agent\": \"PostmanRuntime/7.34.0\",\n        \"accept\": \"*/*\",\n        \"cache-control\": \"no-cache\",\n        \"postman-token\": \"134cbbfb-fb0d-4d17-8345-8add3dda36ff\",\n        \"accept-encoding\": \"gzip, deflate, br\"\n    },\n    \"url\": \"https://postman-echo.com/get\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "POST Request",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"status\": true\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "https://postman-echo.com/post",
+          "protocol": "https",
+          "host": [
+            "postman-echo",
+            "com"
+          ],
+          "path": [
+            "post"
+          ]
+        }
+      },
+      "response": [
+        {
+          "name": "Success",
+          "originalRequest": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"status\": true\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://postman-echo.com/post",
+              "protocol": "https",
+              "host": [
+                "postman-echo",
+                "com"
+              ],
+              "path": [
+                "post"
+              ]
+            }
+          },
+          "status": "OK",
+          "code": 200,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "Date",
+              "value": "Thu, 23 Nov 2023 23:34:07 GMT"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "726"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"2d6-nRABG6UoarONIL57wK8T/BmID2M\""
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"args\": {},\n    \"data\": {\n        \"status\": true\n    },\n    \"files\": {},\n    \"form\": {},\n    \"headers\": {\n        \"x-forwarded-proto\": \"https\",\n        \"x-forwarded-port\": \"443\",\n        \"host\": \"postman-echo.com\",\n        \"x-amzn-trace-id\": \"Root=1-655fe16f-20f0e5486467995a5336ccbf\",\n        \"content-length\": \"22\",\n        \"content-type\": \"application/json\",\n        \"user-agent\": \"PostmanRuntime/7.34.0\",\n        \"accept\": \"*/*\",\n        \"cache-control\": \"no-cache\",\n        \"postman-token\": \"f99dd15a-1cc0-44e5-bbdd-f66749bdb7ed\",\n        \"accept-encoding\": \"gzip, deflate, br\",\n        \"cookie\": \"sails.sid=s%3Akjl66_MYnofvGLeQK9R6H6WE3H6Fnq3e.4MIND71UoLG2S%2BvLQatbVFrxMEo%2BG1APYBx6%2B50vpUI\"\n    },\n    \"json\": {\n        \"status\": true\n    },\n    \"url\": \"https://postman-echo.com/post\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "PUT Request",
+      "request": {
+        "method": "PUT",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"status\": true\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "https://postman-echo.com/put",
+          "protocol": "https",
+          "host": [
+            "postman-echo",
+            "com"
+          ],
+          "path": [
+            "put"
+          ]
+        }
+      },
+      "response": [
+        {
+          "name": "Success",
+          "originalRequest": {
+            "method": "PUT",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"status\": true\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "https://postman-echo.com/put",
+              "protocol": "https",
+              "host": [
+                "postman-echo",
+                "com"
+              ],
+              "path": [
+                "put"
+              ]
+            }
+          },
+          "status": "OK",
+          "code": 200,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "Date",
+              "value": "Thu, 23 Nov 2023 23:36:46 GMT"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "719"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"2cf-i+NvahouosJ1Dtm87c4y2+o+3a4\""
+            },
+            {
+              "key": "set-cookie",
+              "value": "sails.sid=s%3A-wgwzsNHA0eCYjoyXe_dt4dpIwtHnK4i.4orK5GgxoSkplKt9UetjgHCq6zS5pPr7HPOX0PbOink; Path=/; HttpOnly"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"args\": {},\n    \"data\": {\n        \"status\": true\n    },\n    \"files\": {},\n    \"form\": {},\n    \"headers\": {\n        \"x-forwarded-proto\": \"https\",\n        \"x-forwarded-port\": \"443\",\n        \"host\": \"postman-echo.com\",\n        \"x-amzn-trace-id\": \"Root=1-655fe20e-4b25156f72bcac4e0a371039\",\n        \"content-length\": \"22\",\n        \"content-type\": \"application/json\",\n        \"user-agent\": \"PostmanRuntime/7.34.0\",\n        \"accept\": \"*/*\",\n        \"cache-control\": \"no-cache\",\n        \"postman-token\": \"5a9f83b3-e23e-4508-a2f4-e885334b3fa4\",\n        \"accept-encoding\": \"gzip, deflate, br\",\n        \"cookie\": \"sails.sid=s%3Asl1wvDCjbgiBUeMu2rCuHaI51P4I8nU1.ivUzpXb7CulF2HqsVUstx19a0SwEVzaz5SHfNeSGIbk\"\n    },\n    \"json\": {\n        \"status\": true\n    },\n    \"url\": \"https://postman-echo.com/put\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "DELETE Request",
+      "request": {
+        "method": "DELETE",
+        "header": [],
+        "url": {
+          "raw": "https://postman-echo.com/delete",
+          "protocol": "https",
+          "host": [
+            "postman-echo",
+            "com"
+          ],
+          "path": [
+            "delete"
+          ]
+        }
+      },
+      "response": [
+        {
+          "name": "Success",
+          "originalRequest": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "https://postman-echo.com/delete",
+              "protocol": "https",
+              "host": [
+                "postman-echo",
+                "com"
+              ],
+              "path": [
+                "delete"
+              ]
+            }
+          },
+          "status": "OK",
+          "code": 200,
+          "_postman_previewlanguage": "json",
+          "header": [
+            {
+              "key": "Date",
+              "value": "Thu, 23 Nov 2023 23:37:21 GMT"
+            },
+            {
+              "key": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "key": "Content-Length",
+              "value": "652"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "ETag",
+              "value": "W/\"28c-nQgALfAv+CVFam3i53BvxOVU54E\""
+            },
+            {
+              "key": "set-cookie",
+              "value": "sails.sid=s%3ATR_hIReC-F2rqdLWqT-LBzbobzIpl9Kk.XQacX6N3J5EErxiFtCSSOQP9XaXQ%2BLskN29Cg2mW448; Path=/; HttpOnly"
+            }
+          ],
+          "cookie": [],
+          "body": "{\n    \"args\": {},\n    \"data\": {},\n    \"files\": {},\n    \"form\": {},\n    \"headers\": {\n        \"x-forwarded-proto\": \"https\",\n        \"x-forwarded-port\": \"443\",\n        \"host\": \"postman-echo.com\",\n        \"x-amzn-trace-id\": \"Root=1-655fe231-7a391f7e27bfc74b490c454a\",\n        \"user-agent\": \"PostmanRuntime/7.34.0\",\n        \"accept\": \"*/*\",\n        \"cache-control\": \"no-cache\",\n        \"postman-token\": \"89ffbbd1-7ab8-44e8-9e30-b17a217f7842\",\n        \"accept-encoding\": \"gzip, deflate, br\",\n        \"cookie\": \"sails.sid=s%3A-wgwzsNHA0eCYjoyXe_dt4dpIwtHnK4i.4orK5GgxoSkplKt9UetjgHCq6zS5pPr7HPOX0PbOink\",\n        \"content-type\": \"application/json\"\n    },\n    \"json\": null,\n    \"url\": \"https://postman-echo.com/delete\"\n}"
+        }
+      ]
+    },
+    {
+      "name": "HEAD Request",
+      "request": {
+        "method": "HEAD",
+        "header": [],
+        "url": {
+          "raw": "https://postman-echo.com/head",
+          "protocol": "https",
+          "host": [
+            "postman-echo",
+            "com"
+          ],
+          "path": [
+            "head"
+          ]
+        }
+      },
+      "response": [
+        {
+          "name": "Success",
+          "originalRequest": {
+            "method": "HEAD",
+            "header": [],
+            "url": {
+              "raw": "https://postman-echo.com/head",
+              "protocol": "https",
+              "host": [
+                "postman-echo",
+                "com"
+              ],
+              "path": [
+                "head"
+              ]
+            }
+          },
+          "status": "OK",
+          "code": 200,
+          "_postman_previewlanguage": "plain",
+          "header": [
+            {
+              "key": "Date",
+              "value": "Thu, 23 Nov 2023 23:37:59 GMT"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "set-cookie",
+              "value": "sails.sid=s%3An4fodz5ejHvaaQIkrd3-PTxp5hfkz4NW.miVyQ0Pn%2B%2FzrVWcbTX28acahHGuG7eOjxVExQCtDHeU; Path=/; HttpOnly"
+            }
+          ],
+          "cookie": [],
+          "body": null
+        }
+      ]
+    },
+    {
+      "name": "OPTIONS Request",
+      "request": {
+        "method": "OPTIONS",
+        "header": [],
+        "url": {
+          "raw": "https://postman-echo.com/options",
+          "protocol": "https",
+          "host": [
+            "postman-echo",
+            "com"
+          ],
+          "path": [
+            "options"
+          ]
+        }
+      },
+      "response": [
+        {
+          "name": "Success",
+          "originalRequest": {
+            "method": "OPTIONS",
+            "header": [],
+            "url": {
+              "raw": "https://postman-echo.com/options",
+              "protocol": "https",
+              "host": [
+                "postman-echo",
+                "com"
+              ],
+              "path": [
+                "options"
+              ]
+            }
+          },
+          "status": "OK",
+          "code": 200,
+          "_postman_previewlanguage": "plain",
+          "header": [
+            {
+              "key": "Date",
+              "value": "Thu, 23 Nov 2023 23:38:22 GMT"
+            },
+            {
+              "key": "Content-Length",
+              "value": "0"
+            },
+            {
+              "key": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "key": "Access-Control-Allow-Origin",
+              "value": "*"
+            },
+            {
+              "key": "Allow",
+              "value": "OPTIONS"
+            },
+            {
+              "key": "set-cookie",
+              "value": "sails.sid=s%3AcGeFU9Va5a1xKzR9pT8XTKkX7geM0WqK.Gjq7ZLYkM7MNWoYgIUZO8He8ynV7qYJAtJmCl%2BrNuzQ; Path=/; HttpOnly"
+            }
+          ],
+          "cookie": [],
+          "body": null
+        }
+      ]
+    }
+  ]
 }

--- a/test/collections/all-request-types.json
+++ b/test/collections/all-request-types.json
@@ -165,6 +165,11 @@
                 "value": "1"
               },
               {
+                "key": "q",
+                "value": "refigerator",
+                "disabled": true
+              },
+              {
                 "key": "limit",
                 "value": "2"
               },

--- a/test/requestTypesTest.js
+++ b/test/requestTypesTest.js
@@ -23,7 +23,7 @@ describe('Different Request Types', () => {
   })
 
   it('Default GET response with query param with 1 ids', async () => {
-    return await axios.get(`http://localhost:${PORT}/users?page=1&limit=1&filters=company_id+eq+2&filters=id+in+(05ee1e2d-1a80-4384-9d65-3beb16bcfd1a)`).then(res => {
+    return await axios.get(`http://localhost:${PORT}/users?page=1&limit=1&filters=id+in+(05ee1e2d-1a80-4384-9d65-3beb16bcfd1a),company_id+eq+2`).then(res => {
       assert(res.status, 200)
       assert.deepEqual(res.data, {
         metadata: {

--- a/test/requestTypesTest.js
+++ b/test/requestTypesTest.js
@@ -22,6 +22,58 @@ describe('Different Request Types', () => {
     server.start()
   })
 
+  it('Default GET response with query param with 1 ids', async () => {
+    return await axios.get(`http://localhost:${PORT}/users?page=1&limit=1&filters=company_id+eq+2&filters=id+in+(05ee1e2d-1a80-4384-9d65-3beb16bcfd1a)`).then(res => {
+      assert(res.status, 200)
+      assert.deepEqual(res.data, {
+        metadata: {
+          count: 1,
+          page: 1,
+          total_count: 1,
+          total_page: 1
+        },
+        data: {
+          ids: ["05ee1e2d-1a80-4384-9d65-3beb16bcfd1a"],
+        }
+      })
+    })
+  })
+
+  it('Default GET response with query param with ids 9c366ded-4c52-43ed-ab73-db7566f28132 and 8810022b-1fe9-40fb-bd5b-cfb48beaa621', async () => {
+    return await axios.get(`http://localhost:${PORT}/users?page=1&limit=2&filters=company_id+eq+2&filters=id+in+(9c366ded-4c52-43ed-ab73-db7566f28132+8810022b-1fe9-40fb-bd5b-cfb48beaa621)`).then(res => {
+      assert(res.status, 200)
+      assert.deepEqual(res.data, {
+        metadata: {
+          count: 2,
+          page: 1,
+          total_count: 2,
+          total_page: 1
+        },
+        data: {
+          ids: ["9c366ded-4c52-43ed-ab73-db7566f28132", "8810022b-1fe9-40fb-bd5b-cfb48beaa621"],
+        }
+      })
+    })
+  })
+
+  it('Default GET response with query param with ids 05ee1e2d-1a80-4384-9d65-3beb16bcfd1a and 8810022b-1fe9-40fb-bd5b-cfb48beaa621', async () => {
+    return await axios.get(`http://localhost:${PORT}/users?page=1&limit=2&filters=company_id+eq+2&filters=id+in+(05ee1e2d-1a80-4384-9d65-3beb16bcfd1a+8810022b-1fe9-40fb-bd5b-cfb48beaa621)`).then(res => {
+      assert(res.status, 200)
+      assert.deepEqual(res.data, {
+        metadata: {
+          count: 2,
+          page: 1,
+          total_count: 2,
+          total_page: 1
+        },
+        data: {
+          ids: ["05ee1e2d-1a80-4384-9d65-3beb16bcfd1a", "8810022b-1fe9-40fb-bd5b-cfb48beaa621"],
+        }
+      })
+    })
+  })
+
+
   it('Success GET response test.', async () => {
     return await axios.get(`http://localhost:${PORT}/get`).then(res => {
       assert(res.data.url === 'https://postman-echo.com/get')


### PR DESCRIPTION
i found an issues about this repo when it trying to match response with query param, even though my request is exactly the same as the document response.originalRequest, it still cannot match. 

The issues is the document query doesn't count for the same key, and its does not decode the query values.
reproduction of the bug  
1. copy ./test/collections/all-request-types.json to main branch
2. copy requestTypesTest.js to the main brach
3. run the test