### PR TITLE
Fix dependency error on express version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   "dependencies": {
     "@faker-js/faker": "^7.4.0",
     "apicache-extra": "^1.9.1",
-    "express": ">=4.19.2",
+    "express": "^4.19.2",
     "fastest-levenshtein": "^1.0.16",
-    "follow-redirects": ">=1.15.6",
+    "follow-redirects": "^1.15.6",
     "http": "^0.0.1-security",
     "https": "^1.0.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
There is the following error when running the postman-local cli :

`TypeError: Missing parameter name at 1: https:///git.new/pathToRegexpError`. It is due to a new major version of `path-to-regexp` being used : `path-to-regexp` is a dependency of `router`, itself being a dependency of `express`. Currently the `>=` in the version allows to get any version above the one specified.

By using `^` for the versions instead of `>=` we ensure that we are keeping the same major version.

I've also made the change to the `follow-redirects` dependency to avoid the same issue.